### PR TITLE
Health checks need to be allowed on UDP 5555 instead of TCP 5555

### DIFF
--- a/tasks/octavia_sec_group.yml
+++ b/tasks/octavia_sec_group.yml
@@ -73,7 +73,7 @@
   openstack.cloud.security_group_rule:
     security_group: "{{ create_lb_health_mgr_secgroup.security_group.id }}"
     state: present
-    protocol: tcp
+    protocol: udp
     port_range_min: 5555
     port_range_max: 5555
     interface: admin


### PR DESCRIPTION
Updated rule to use UDP instead of TCP